### PR TITLE
Defer Math.LN2 division until last step

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,13 +20,11 @@ function shannon(buf, start, end){
   }
 
   for (var i = 0; i < keys.length; i++) {
-    H += C[keys[i]] * log2(C[keys[i]]);
+    H += C[keys[i]] * Math.log(C[keys[i]]);
   }
+
+  // log2(x) = Math.log(x) / Math.LN2
+  H /= Math.LN2;
 
   return -H;
 }
-
-function log2(x){
-  return Math.log(x) / Math.LN2;
-}
-


### PR DESCRIPTION
In this PR the division by `Math.LN2` is performed at the end once all elements have been added. This way, a single operation needs to be executed instead of one for each key found in the data. This provides a small performance gain (around 5% with random data according to the benchmark script).
